### PR TITLE
Proper root path declaration

### DIFF
--- a/tasks/duo.js
+++ b/tasks/duo.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
     var done = this.async();
 
     (function compile () {
-      var duo = new Duo(options.root)
+      var duo = new Duo(path.join(process.cwd(), options.root))
         .entry(options.entry)
         .standalone(options.standalone)
         .development(options.development)


### PR DESCRIPTION
Added proper  root path declaration.

Without joining of `process.cwd()` with `options.root` DuoJS won't know where to look for components, since `options.root` without appending with `process.cwd()` literally means to look in that path, starting from elsewhere, but not working directory of Grunt.

Thus, without fix that Task will result in incomplete build:

``` cofffee
module.exports = (grunt) ->
  @config 'duojs',
    build:
      options:
        root: '<%= path.source.scripts %>'
        buildTo: '../../<%= path.build.scripts %>'
        entry: 'main.js'
        installTo: '../../<%= path.temp.root %>'
```

since Duo won't know where `<%= path.source.scripts %>` located.

That PR fixes that issue.
